### PR TITLE
Bump Go to 1.22

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,9 @@ issues:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - dupl
     - errcheck
-    - exportloopref
     - goconst
     - gocyclo
     - gofmt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.2.1
-CONTROLLER_TOOLS_VERSION ?= v0.13.0
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.59.1
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/pfnet/image-pull-secrets-provisioner
 
-go 1.21
+go 1.22
+
+toolchain go1.22.5
 
 require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27

--- a/hack/credits.Dockerfile
+++ b/hack/credits.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /workspace
 

--- a/internal/controller/aws_test.go
+++ b/internal/controller/aws_test.go
@@ -39,7 +39,6 @@ func TestAWSExtractRegion(t *testing.T) {
 			wantErr:  true,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/controller/evictor.go
+++ b/internal/controller/evictor.go
@@ -238,7 +238,6 @@ func (e *evictor) listPodsToEvict(
 
 	targets := []*corev1.Pod{}
 	for _, pod := range pods.Items {
-		pod := pod
 		if e.hasImagePullSecret(&pod, secret) {
 			continue
 		}

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -431,12 +431,11 @@ func (r *serviceAccountReconciler) listImagePullSecretsToCleanup(
 
 	targets := []*corev1.Secret{}
 	for _, secret := range secrets.Items {
-		secret := &secret
 		if secret.GetName() == inUse {
 			continue
 		}
 
-		targets = append(targets, secret)
+		targets = append(targets, &secret)
 	}
 
 	return targets, nil


### PR DESCRIPTION
To prevent the loop variable problem, let's bump Go to 1.22.
https://go.dev/blog/loopvar-preview

controller-tools is also updated because the old version causes panic with Go 1.22.