### PR TITLE
Fix image pull secret name

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ rules:
    See also [Configure Service Accounts for Pods | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
 4. The pod will be able to pull container images from the registry
 
+## Image pull secret name
+
+By default, image pull secrets provisioner creates an image pull secret with the name `imagepullsecret-SERVICE-ACCOUNT-NAME`.
+If you want to use a different name, you can specify it in the ServiceAccount's annotation.
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: NAMESPACE
+  name: SERVICE-ACCOUNT-NAME
+  annotations:
+    imagepullsecrets.preferred.jp/secret-name: SECRET-NAME
+```
+
 ## Pod eviction
 
 Image pull secrets added to a ServiceAccount's `.imagePullSecrets` field do *not* apply to existing pods using the ServiceAccount.

--- a/internal/controller/metadata.go
+++ b/internal/controller/metadata.go
@@ -31,6 +31,8 @@ const (
 	annotationKeyGoogleWIDP = metadataKeyPrefix + "googlecloud-workload-identity-provider"
 	annotationKeyGoogleSA   = metadataKeyPrefix + "googlecloud-service-account-email"
 
+	annotationKeySecretName = metadataKeyPrefix + "secret-name"
+
 	// Annotation for Secrets to store the expiration time.
 	annotationKeyExpiresAt = metadataKeyPrefix + "expires-at"
 

--- a/internal/controller/serviceaccount_controller_test.go
+++ b/internal/controller/serviceaccount_controller_test.go
@@ -208,9 +208,9 @@ var _ = Describe("ServiceAccountReconciler", func() {
 				outdated = &secrets.Items[0]
 			}).Should(Succeed())
 
-			// Change the config for image pull secret provisioning.
+			// Change the name of Secret to provision.
 			orig := sa.DeepCopy()
-			sa.Annotations["imagepullsecrets.preferred.jp/googlecloud-service-account-email"] = "other@example.iam.gserviceaccount.com"
+			sa.Annotations["imagepullsecrets.preferred.jp/secret-name"] = "imagepullsecret-2"
 			Expect(k8sClient.Patch(ctx, sa, client.StrategicMergeFrom(orig))).NotTo(HaveOccurred())
 
 			// Test that a new Secret is created and the outdated Secret is deleted.


### PR DESCRIPTION
to prevent the issue in the following scenario:

1. An image pull secret is provisioned, and a Pod successfully pulls image and starts
2. ServiceAccount's annotation is changed, resulting in a change of the image pull secret name
3. The Pod attempts to pull the image again for some reason
4. The old image pull secret has been deleted, causing the Pod to fail in pulling the image
5. Since the Pod initially started successfully in step 1, the evictor does not recover the Pod