### PR TITLE
Add `ecr:BatchCheckLayerAvailability` action to an ECR example

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ data "aws_iam_policy_document" "repository_policy" {
     actions = [
       "ecr:BatchGetImage",
       "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchCheckLayerAvailability",
     ]
   }
 }


### PR DESCRIPTION
This PR adds `ecr:BatchCheckLayerAvailability` as the required permission for pulling from Amazon ECR registry.

This permission may be required when using EKS nodes or ECR proxy.
https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_on_EKS.html#ECR_on_EKS_iampermissions
https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_BatchCheckLayerAvailability.html