### PR TITLE
Add '--expiration-grace-period-minutes' option to specify expirationGracePeriod

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -57,6 +58,7 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var disablePodEviction bool
+	var expirationGracePeriodMinutes int
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -65,6 +67,8 @@ func main() {
 	flag.BoolVar(&disablePodEviction, "disable-pod-eviction", false,
 		"Disable evicting pods that are failing to pull container images"+
 			" because they do not have an image pull secret provisioned for their ServiceAccount.")
+	flag.IntVar(&expirationGracePeriodMinutes, "expiration-grace-period-minutes", 1,
+		"The expiration grace period for image pull secrets in minutes. The value must be between 1 and 45.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -117,12 +121,16 @@ func main() {
 	}
 
 	ctx := ctrl.SetupSignalHandler()
+	saReconcilerConfig := controller.NewDefaultServiceAccountReconcilerConfig()
+	saReconcilerConfig.ExpirationGracePeriod = time.Duration(expirationGracePeriodMinutes) * time.Minute
+	setupLog.Info("ServiceAccountReconcilerConfig", "ExpirationGracePeriod", saReconcilerConfig.ExpirationGracePeriod)
 
 	if sa, err := controller.NewServiceAccountReconciler(
 		ctx,
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		mgr.GetEventRecorderFor("image-pull-secrets-provisioner"),
+		saReconcilerConfig,
 	); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ServiceAccount")
 		os.Exit(1)

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -39,7 +39,7 @@ import (
 const (
 	minExpirationGracePeriod = time.Minute
 
-	// Cap the maximum token lifetime to 45 minutes to prevent tokens from reaching their maximum lifetime of 1 hour.
+	// Cap the maximum expiration grace period to 45 minutes to avoid using tokens close to their 1 hour maximum lifetime.
 	maxExpirationGracePeriod = 45 * time.Minute
 )
 

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -36,6 +36,34 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const (
+	minExpirationGracePeriod = time.Minute
+
+	// Cap the maximum token lifetime to 45 minutes to prevent tokens from reaching their maximum lifetime of 1 hour.
+	maxExpirationGracePeriod = 45 * time.Minute
+)
+
+type ServiceAccountReconcilerConfig struct {
+	ExpirationGracePeriod time.Duration
+}
+
+func NewDefaultServiceAccountReconcilerConfig() *ServiceAccountReconcilerConfig {
+	return &ServiceAccountReconcilerConfig{
+		ExpirationGracePeriod: minExpirationGracePeriod,
+	}
+}
+
+func (c *ServiceAccountReconcilerConfig) validate() error {
+	if c.ExpirationGracePeriod < minExpirationGracePeriod || c.ExpirationGracePeriod > maxExpirationGracePeriod {
+		return fmt.Errorf(
+			"expiration grace period must be between %v and %v: %v",
+			minExpirationGracePeriod, maxExpirationGracePeriod, c.ExpirationGracePeriod,
+		)
+	}
+
+	return nil
+}
+
 type serviceAccountReconciler struct {
 	client.Client
 	*runtime.Scheme
@@ -52,7 +80,15 @@ type serviceAccountReconciler struct {
 // the ServiceAccount can pull container images using the secret without specifying .spec.imagePullSecrets field.
 func NewServiceAccountReconciler(
 	ctx context.Context, client client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder,
+	cfg *ServiceAccountReconcilerConfig,
 ) (*serviceAccountReconciler, error) {
+	if cfg == nil {
+		return nil, errors.New("cfg must not be nil")
+	}
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
 	g, err := newGoogle(ctx)
 	if err != nil {
 		return nil, err
@@ -64,7 +100,7 @@ func NewServiceAccountReconciler(
 		eventRecorder:         eventRecorder,
 		aws:                   newAWS(),
 		google:                g,
-		expirationGracePeriod: time.Minute,
+		expirationGracePeriod: cfg.ExpirationGracePeriod,
 	}, nil
 }
 

--- a/internal/controller/serviceaccount_controller_test.go
+++ b/internal/controller/serviceaccount_controller_test.go
@@ -676,3 +676,48 @@ var _ = Describe("ServiceAccountReconciler", func() {
 		// Other test cases are omitted because they are covered by the Google test cases.
 	})
 })
+
+var _ = Describe("ServiceAccountReconcilerConfig", func() {
+	Describe("NewDefaultServiceAccountReconcilerConfig", func() {
+		It("returns a config that passes validation", func() {
+			cfg := NewDefaultServiceAccountReconcilerConfig()
+			Expect(cfg.ExpirationGracePeriod).To(Equal(time.Minute))
+			Expect(cfg.validate()).To(Succeed())
+		})
+	})
+
+	DescribeTable("validate",
+		func(period time.Duration, expectError bool) {
+			cfg := &ServiceAccountReconcilerConfig{ExpirationGracePeriod: period}
+			err := cfg.validate()
+			if expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		Entry("shorter than the minimum", 30*time.Second, true),
+		Entry("negative", -time.Minute, true),
+		Entry("at the minimum", time.Minute, false),
+		Entry("between the minimum and the maximum", 10*time.Minute, false),
+		Entry("at the maximum", 45*time.Minute, false),
+		Entry("longer than the maximum", 46*time.Minute, true),
+	)
+
+	Describe("NewServiceAccountReconciler", func() {
+		It("returns an error when cfg is nil", func() {
+			r, err := NewServiceAccountReconciler(context.Background(), nil, nil, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(r).To(BeNil())
+		})
+
+		It("returns an error when cfg is invalid", func() {
+			r, err := NewServiceAccountReconciler(
+				context.Background(), nil, nil, nil,
+				&ServiceAccountReconcilerConfig{ExpirationGracePeriod: time.Second},
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(r).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
This PR introduces the `--expiration-grace-period-minutes` option to adjust token renewal grace periods. 
It helps prevent token expiration during longer image pulls.