### PR TITLE
Migrate controller event recording to the new Events API

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -129,7 +129,7 @@ func main() {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetScheme(),
-		mgr.GetEventRecorderFor("image-pull-secrets-provisioner"),
+		mgr.GetEventRecorder("image-pull-secrets-provisioner"),
 		saReconcilerConfig,
 	); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ServiceAccount")
@@ -143,7 +143,7 @@ func main() {
 		if err = controller.NewEvictor(
 			mgr.GetClient(),
 			mgr.GetScheme(),
-			mgr.GetEventRecorderFor("image-pull-secrets-provisioner"),
+			mgr.GetEventRecorder("image-pull-secrets-provisioner"),
 		).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create evictor")
 			os.Exit(1)

--- a/internal/controller/evictor.go
+++ b/internal/controller/evictor.go
@@ -26,7 +26,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +37,7 @@ import (
 type evictor struct {
 	client.Client
 	*runtime.Scheme
-	eventRecorder record.EventRecorder
+	eventRecorder events.EventRecorder
 	// requeueAfter is the interval to requeue the reconciliation to reevaluate pods or to retry eviction that failed
 	// due to PodDisruptionBudget violation.
 	// TODO: Split into two fields if we need to set different intervals for each case.
@@ -47,7 +47,7 @@ type evictor struct {
 // NewEvictor creates a new ServiceAccount reconciler that evicts pods that are failing to pull container images because
 // they do not have an image pull secret provisioned for their ServiceAccount.
 func NewEvictor(
-	client client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder,
+	client client.Client, scheme *runtime.Scheme, eventRecorder events.EventRecorder,
 ) *evictor {
 	return &evictor{
 		Client:        client,
@@ -71,6 +71,9 @@ const (
 	// Event reasons.
 	reasonFailedEviction = "FailedEvictionForImagePullSecret"
 	reasonEvicted        = "EvictedForImagePullSecret"
+
+	// Event actions.
+	actionEvict = "Evict"
 )
 
 func (e *evictor) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -131,7 +134,7 @@ func (e *evictor) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result,
 		if err := e.SubResource("eviction").Create(ctx, pod, &policyv1.Eviction{}); err != nil {
 			if apierrors.IsTooManyRequests(err) {
 				e.eventRecorder.Eventf(
-					pod, corev1.EventTypeWarning, reasonFailedEviction,
+					pod, nil, corev1.EventTypeWarning, reasonFailedEviction, actionEvict,
 					"Eviction failed due to PodDisruptionBudget violation: %v", err,
 				)
 				logger.Info("Eviction failed due to PodDisruptionBudget violation: " + err.Error())
@@ -139,15 +142,15 @@ func (e *evictor) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result,
 				continue
 			}
 
-			e.eventRecorder.Eventf(pod, corev1.EventTypeWarning, reasonFailedEviction, "Eviction failed: %v", err)
+			e.eventRecorder.Eventf(pod, nil, corev1.EventTypeWarning, reasonFailedEviction, actionEvict, "Eviction failed: %v", err)
 			logger.Error(err, "failed to evict a pod")
 			// It is OK to throw away old error because it was logged.
 			rerr = err
 			continue
 		}
 
-		e.eventRecorder.Event(
-			pod, corev1.EventTypeNormal, reasonEvicted,
+		e.eventRecorder.Eventf(
+			pod, nil, corev1.EventTypeNormal, reasonEvicted, actionEvict,
 			"Evicted because the pod is failing to pull container images"+
 				" and does not have an image pull secret provisioned for its ServiceAccount.",
 		)

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -163,7 +163,7 @@ func (r *serviceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		r.eventRecorder.Eventf(
 			sa, nil, corev1.EventTypeWarning, reasonFailedDecommissioning, actionDecommission,
-			"Failed to decommissioning outdated image pull secrets: %v", err,
+			"Failed to decommission outdated image pull secrets: %v", err,
 		)
 		logger.Error(err, "failed to cleanup outdated image pull secrets")
 		return ctrl.Result{}, err

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -29,7 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -67,7 +67,7 @@ func (c *ServiceAccountReconcilerConfig) validate() error {
 type serviceAccountReconciler struct {
 	client.Client
 	*runtime.Scheme
-	eventRecorder record.EventRecorder
+	eventRecorder events.EventRecorder
 	aws           aws
 	google        google
 	// Grace period for refreshing image pull secrets before they expires.
@@ -79,7 +79,7 @@ type serviceAccountReconciler struct {
 // Image pull secrets are attached to a ServiceAccount (i.e. registered with .imagePullSecrets field) so that pods using
 // the ServiceAccount can pull container images using the secret without specifying .spec.imagePullSecrets field.
 func NewServiceAccountReconciler(
-	ctx context.Context, client client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder,
+	ctx context.Context, client client.Client, scheme *runtime.Scheme, eventRecorder events.EventRecorder,
 	cfg *ServiceAccountReconcilerConfig,
 ) (*serviceAccountReconciler, error) {
 	if cfg == nil {
@@ -115,6 +115,10 @@ const (
 
 	reasonFailedDecommissioning    = "FailedDecommissioningImagePullSecret"
 	reasonSucceededDecommissioning = "DecommissionedImagePullSecret"
+
+	// Event actions.
+	actionProvision    = "Provision"
+	actionDecommission = "Decommission"
 )
 
 func (r *serviceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -158,7 +162,7 @@ func (r *serviceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	decommissioned, err := r.cleanupImagePullSecrets(ctx, logger, sa)
 	if err != nil {
 		r.eventRecorder.Eventf(
-			sa, corev1.EventTypeWarning, reasonFailedDecommissioning,
+			sa, nil, corev1.EventTypeWarning, reasonFailedDecommissioning, actionDecommission,
 			"Failed to decommissioning outdated image pull secrets: %v", err,
 		)
 		logger.Error(err, "failed to cleanup outdated image pull secrets")
@@ -167,7 +171,7 @@ func (r *serviceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	if len(decommissioned) > 0 {
 		r.eventRecorder.Eventf(
-			sa, corev1.EventTypeNormal, reasonSucceededDecommissioning,
+			sa, nil, corev1.EventTypeNormal, reasonSucceededDecommissioning, actionDecommission,
 			"Decommissioned outdated image pull secrets: %v", decommissioned,
 		)
 	}
@@ -204,16 +208,16 @@ func (r *serviceAccountReconciler) provisionImagePullSecretForPrincipal(
 
 	secret, newExp, err := r.createOrRefreshImagePullSecret(ctx, logger, sa, secretName, principal)
 	if err != nil {
-		r.eventRecorder.Eventf(sa, corev1.EventTypeWarning, reasonFailedProvisioning, "Failed to create or refresh an image pull secret: %v", err)
+		r.eventRecorder.Eventf(sa, nil, corev1.EventTypeWarning, reasonFailedProvisioning, actionProvision, "Failed to create or refresh an image pull secret: %v", err)
 		return time.Time{}, fmt.Errorf("failed to create or refresh an image pull secret: %w", err)
 	}
 
 	if err := r.attachImagePullSecret(ctx, logger, sa, secret); err != nil {
-		r.eventRecorder.Eventf(sa, corev1.EventTypeWarning, reasonFailedProvisioning, "Failed to add an image pull secret to the ServiceAccount: %v", err)
+		r.eventRecorder.Eventf(sa, nil, corev1.EventTypeWarning, reasonFailedProvisioning, actionProvision, "Failed to add an image pull secret to the ServiceAccount: %v", err)
 		return time.Time{}, fmt.Errorf("failed to attach an image pull secret to a ServiceAccount: %w", err)
 	}
 
-	r.eventRecorder.Eventf(sa, corev1.EventTypeNormal, reasonSucceededProvisioning, "Provisioned an image pull secret: %s", secret.GetName())
+	r.eventRecorder.Eventf(sa, nil, corev1.EventTypeNormal, reasonSucceededProvisioning, actionProvision, "Provisioned an image pull secret: %s", secret.GetName())
 
 	return newExp, nil
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&serviceAccountReconciler{
 		Client:                k8sManager.GetClient(),
 		Scheme:                k8sManager.GetScheme(),
-		eventRecorder:         k8sManager.GetEventRecorderFor("image-pull-secrets-provisioner"),
+		eventRecorder:         k8sManager.GetEventRecorder("image-pull-secrets-provisioner"),
 		aws:                   &awsMock{},
 		google:                &gMock{},
 		expirationGracePeriod: 0, // To test skipping refreshing Secrets.
@@ -126,7 +126,7 @@ var _ = BeforeSuite(func() {
 	err = (&evictor{
 		Client:        k8sManager.GetClient(),
 		Scheme:        k8sManager.GetScheme(),
-		eventRecorder: k8sManager.GetEventRecorderFor("image-pull-secrets-provisioner"),
+		eventRecorder: k8sManager.GetEventRecorder("image-pull-secrets-provisioner"),
 		requeueAfter:  100 * time.Millisecond,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

- migrate controller event recording from `GetEventRecorderFor` to `GetEventRecorder`
- use `events.EventRecorder` and update event calls to the new `Eventf` signature

This fixes the mismatch introduced by the `events.k8s.io` RBAC change in #176: normal controller events were still being sent to the legacy core/v1 Events API.

The leader-election role remains unchanged because controller-runtime still uses the legacy recorder internally for leader election.

Related: #178